### PR TITLE
feat: add Slack notifications for CI workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,55 @@ jobs:
         run: python .github/scripts/validate_schema.py
         continue-on-error: true
 
+      - name: Notify Slack on validation failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🚨 CI Validation Failed",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🚨 CI Validation Failed"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n${{ github.workflow }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Job:*\nValidate Content & Quality"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>"
+                  }
+                }
+              ]
+            }
+        continue-on-error: true
+
   security:
     name: Security Scanning
     runs-on: ubuntu-latest
@@ -80,4 +129,53 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+        continue-on-error: true
+
+      - name: Notify Slack on security scan failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🔒 Security Scan Failed",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🔒 Security Scan Failed"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n${{ github.workflow }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Job:*\nSecurity Scanning"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Security Report>"
+                  }
+                }
+              ]
+            }
         continue-on-error: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -64,3 +64,44 @@ jobs:
               body: body,
               labels: ['automated', 'broken-link', 'maintenance']
             });
+
+      - name: Notify Slack on link check failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🔗 Broken Links Detected",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🔗 Broken Links Detected"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n${{ github.workflow }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.ref_name }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The automated link checker has detected broken links.\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>"
+                  }
+                }
+              ]
+            }
+        continue-on-error: true


### PR DESCRIPTION
## Summary
Adds Slack notifications for CI workflow failures to ensure maintainers are immediately alerted when validation, security scans, or link checks fail. Reduces response time to critical failures by providing real-time notifications in Slack channels with direct links to workflow runs.

## Changes
- Added Slack notification step to CI validation job (triggers on failure)
- Added Slack notification step to CI security scanning job (triggers on failure)
- Added Slack notification step to link-check workflow (triggers on failure)
- Notifications include:
  - Workflow name and job name
  - Branch name and triggering user
  - Direct link to workflow run for investigation
  - Appropriate emoji indicators (🚨 for validation, 🔒 for security, 🔗 for links)
- Used slackapi/slack-github-action@v1 (official Slack action)
- Set continue-on-error to true (notification failure doesn't fail workflow)

## Type of Change
- [x] New feature (observability enhancement)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security patch

## Configuration Required
This feature requires repository secret configuration:

1. **Create Slack Webhook URL**:
   - Go to Slack App settings
   - Create Incoming Webhook for desired channel (e.g., `#ci-alerts`)
   - Copy webhook URL

2. **Add to Repository Secrets**:
   - Go to repository Settings → Secrets and variables → Actions
   - Add new secret: `SLACK_WEBHOOK_URL`
   - Paste webhook URL as value

3. **Notifications will work immediately** after secret is configured

## Notification Format
Structured Slack message blocks with:
- Header with emoji and status
- Field grid showing workflow context
- Action button to view workflow run
- Clean, professional formatting

## Benefits
- **Faster Response**: Real-time alerts instead of email notifications
- **Better Visibility**: Team channel visibility vs. individual emails
- **Reduced MTTR**: Direct links to failures accelerate investigation
- **Flexibility**: Can be configured for any Slack channel
- **Non-blocking**: Notification failures don't impact workflow success

## Alternative: Discord
To use Discord instead:
1. Create Discord webhook in channel settings
2. Replace `webhook-url` with Discord webhook URL
3. Adjust payload format for Discord (simpler JSON structure)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Notifications trigger only on failure
- [x] Continue-on-error set to true
- [x] Documentation updated (setup instructions in PR)
- [x] No new warnings introduced

## Testing
- Notifications can be tested by:
  - Intentionally breaking validation (add invalid entry)
  - Triggering workflow manually
  - Verifying Slack message receipt

## Related Issues
Addresses observability requirements by adding proactive failure notifications