### PR TITLE
chore: CI hardening, fix project-health workflow, bump Python deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   validate:
     name: Validate Content & Quality
@@ -28,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g markdownlint-cli markdown-link-check
-          pip install pyyaml jsonschema
+          pip install -r requirements.txt
 
       - name: Markdown linting
         run: markdownlint '**/*.md' --ignore node_modules --ignore .github
@@ -60,8 +64,10 @@ jobs:
         continue-on-error: true
 
       - name: Notify Slack on validation failure
-        if: failure()
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -117,7 +123,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy security scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -132,8 +138,10 @@ jobs:
         continue-on-error: true
 
       - name: Notify Slack on security scan failure
-        if: failure()
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - '**.md'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   link-checker:
     name: Check All Links
@@ -74,8 +78,10 @@ jobs:
             });
 
       - name: Notify Slack on link check failure
-        if: failure()
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   triage:
     name: Auto-label and Validate PR

--- a/.github/workflows/project-health.yml
+++ b/.github/workflows/project-health.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   update-metrics:
     name: Update Project Metrics
@@ -50,8 +54,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if [[ -n $(git status --porcelain) ]]; then
-            git add data/project-metrics.json data/dashboard-data.json data/badge-data.json data/tracked-projects.json feed.xml
+          git add -f data/project-metrics.json data/dashboard-data.json data/badge-data.json data/tracked-projects.json
+          git add feed.xml
+
+          if [[ -n $(git diff --cached --name-only) ]]; then
             git commit -m "Update project health metrics and RSS feed [automated]"
             git push
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to awesome-autonomous-ops will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-25
+
+### Added
+
+- **[KubeStellar Console](https://github.com/kubestellar/console)** — AI-powered multi-cluster Kubernetes dashboard added to the Agentic Remediation & Runbooks section (CNCF Sandbox, Apache 2.0). Contributed by @clubanderson in PR #17.
+
+### Fixed
+
+- **Project Health Tracking workflow** — Daily scheduled workflow was failing because `.gitignore` blocked `data/*.json` from being committed. Changed to `git add -f` so generated metrics, badges, and RSS feed data are published correctly.
+
+### Changed
+
+- **CI hardening** — Added least-privilege `permissions:` blocks to all workflow files. Pinned `aquasecurity/trivy-action` from `@master` to `@v0.36.0`. Gated Slack notification steps on `SLACK_WEBHOOK_URL` secret presence to eliminate noise on forks and unconfigured repos. Switched CI validation to use pinned `requirements.txt` instead of ad-hoc `pip install`.
+- **Dependabot bumps** — Merged 5 GitHub Actions version bumps: `github/codeql-action` v3 to v4, `actions/upload-pages-artifact` v3 to v4, `actions/first-interaction` v1 to v3, `actions/setup-node` v4 to v6, `actions/github-script` v7 to v8.
+- **Python dependency refresh** — Bumped `requests` 2.32.3 to 2.33.1, `PyYAML` 6.0.2 to 6.0.3, `jsonschema` 4.23.0 to 4.26.0, `pytest` 8.3.4 to 9.0.3, `pytest-cov` 6.0.0 to 7.1.0, `black` 24.10.0 to 26.3.1, `flake8` 7.1.1 to 7.3.0, `pylint` 3.3.2 to 4.0.5, `mypy` 1.13.0 to 1.20.2, `pip-audit` 2.7.3 to 2.10.0.
+
 ## [2.0.0] - 2025-11-23
 
 ### Added - Infrastructure & Automation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,19 +5,19 @@
 -r requirements.txt
 
 # Testing framework
-pytest==8.3.4
-pytest-cov==6.0.0
+pytest==9.0.3
+pytest-cov==7.1.0
 
 # Code quality tools
-black==24.10.0
-flake8==7.1.1
-pylint==3.3.2
+black==26.3.1
+flake8==7.3.0
+pylint==4.0.5
 
 # Type checking
-mypy==1.13.0
-types-requests==2.32.0.20241016
-types-PyYAML==6.0.12.20240917
+mypy==1.20.2
+types-requests==2.33.0.20260408
+types-PyYAML==6.0.12.20260408
 
 # Security scanning
-pip-audit==2.7.3
+pip-audit==2.10.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@
 # These are used by validation scripts and CI workflows
 
 # HTTP client for GitHub API interactions
-requests==2.32.3
+requests==2.33.1
 
 # YAML parsing for configuration files
-PyYAML==6.0.2
+PyYAML==6.0.3
 
 # JSON schema validation for structured data
-jsonschema==4.23.0
+jsonschema==4.26.0
 


### PR DESCRIPTION
## Summary

- **Fix broken Project Health Tracking workflow** — The daily scheduled workflow has been failing on every run since creation because `.gitignore` blocks `data/*.json` but the workflow tried to `git add` those files. Changed to `git add -f` and detect changes via `git diff --cached`.
- **Harden CI/CD security posture** — Added least-privilege `permissions:` blocks to all four workflow files (ci, link-check, pr-triage, project-health). Pinned `aquasecurity/trivy-action` from mutable `@master` to `@v0.36.0`. Gated all Slack notification steps on `SLACK_WEBHOOK_URL` secret presence so they don't produce noisy failures on forks or when the secret is unconfigured. Switched CI validation from ad-hoc `pip install pyyaml jsonschema` to `pip install -r requirements.txt` for version consistency.
- **Bump Python dependencies** — Updated all pinned versions to latest stable: requests 2.33.1, PyYAML 6.0.3, jsonschema 4.26.0, pytest 9.0.3, pytest-cov 7.1.0, black 26.3.1, flake8 7.3.0, pylint 4.0.5, mypy 1.20.2, pip-audit 2.10.0.
- **Changelog** — Added v2.1.0 entry covering KubeStellar Console addition (PR #17), this hardening work, and the Dependabot bumps (PRs #3-#7).

## Context

This PR follows the merge of 5 Dependabot PRs (#3-#7) and PR #17 (KubeStellar Console). Together they bring the repo current after several months of accumulated alerts and stale action versions.

## Manual follow-ups (not in this PR)

- **Enable Dependabot security alerts** in repo Settings > Code security — currently disabled, so vulnerability scanning doesn't run.
- **Node.js 24 migration** — GitHub Actions will force Node.js 24 for all actions starting June 2, 2026. The `actions/setup-node@v6` bump (PR #6) already supports this, but `actions/checkout@v4`, `actions/cache@v4`, and `actions/setup-python@v5` will need updates when their v5+ releases land.

## Test plan

- [ ] Trigger `Project Health Tracking` workflow manually (`workflow_dispatch`) and verify it completes without the `paths are ignored` error
- [ ] Verify CI runs on this PR pass (markdown lint, YAML validation, Trivy scan)
- [ ] Confirm dynamic project-count badge on README updates after next successful health run

Made with [Cursor](https://cursor.com)