### PR TITLE
fix: resolve broken links detected by link health check

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 GitHub Discussions
-    url: https://github.com/nik-kale/awesome-autonomous-ops/discussions
+  - name: 💬 GitHub Issues
+    url: https://github.com/nik-kale/awesome-autonomous-ops/issues
     about: Ask questions, share ideas, or discuss autonomous ops topics
   - name: 📖 Contributing Guidelines
     url: https://github.com/nik-kale/awesome-autonomous-ops/blob/main/CONTRIBUTING.md

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Lychee Link Checker
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --verbose --no-progress '**/*.md' '**/*.html' --exclude-path node_modules --exclude-path .git
+          args: --verbose --no-progress '**/*.md' --exclude-path node_modules --exclude-path .git
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,11 @@
+# Jekyll Liquid template URLs (only valid after build)
+{{ site.github.repository_url }}
+
+# Relative paths without extensions (resolved by Jekyll/GitHub Pages)
+file:///.*COMPARISONS$
+file:///.*CONTRIBUTING$
+file:///.*ARCHITECTURES$
+file:///.*GETTING-STARTED$
+file:///.*GLOSSARY$
+file:///.*dashboard$
+file:///.*security/advisories/new$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,5 +177,5 @@ See [ROADMAP.md](ROADMAP.md) for complete future plans.
 
 ---
 
-[2.0.0]: https://github.com/nik-kale/awesome-autonomous-ops/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/nik-kale/awesome-autonomous-ops/releases/tag/v1.0.0
+[2.0.0]: https://github.com/nik-kale/awesome-autonomous-ops/compare/d6a58e7...main
+[1.0.0]: https://github.com/nik-kale/awesome-autonomous-ops/commit/d6a58e7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,9 @@ Use this format:
 **Examples**:
 
 ```markdown
-- **[Sage](https://github.com/apple/ml-sage)** – Apple's system for grounding LLM reasoning in structured incident data. Uses semantic search and entity graphs to improve diagnostic accuracy.
-
 - **[Robusta](https://github.com/robusta-dev/robusta)** – Kubernetes troubleshooting and automation platform. Provides diagnostic playbooks and auto-remediation capabilities.
+
+- **[LangGraph](https://github.com/langchain-ai/langgraph)** – Framework for building stateful, graph-based AI workflows. Useful for orchestrating multi-step diagnostic and remediation processes with cyclical reasoning.
 ```
 
 ### 3. Submit a Pull Request

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -109,8 +109,7 @@ For a **proof-of-concept autonomous ops system**, you need:
 
 **Option A: MCP Servers** (If APIs exist)
 - **Tools**:
-  - [MCP Prometheus Server](https://github.com/modelcontextprotocol/servers/tree/main/src/prometheus)
-  - [MCP GitHub Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github)
+  - [GitHub MCP Server](https://github.com/github/github-mcp-server)
   - [MCP Kubernetes](https://github.com/kubernetes/kubernetes) (custom implementation)
 - **Why**: Secure, structured access to operational tools
 - **Effort**: 2-4 days per integration
@@ -356,7 +355,7 @@ Recommendation: Increase connection pool size or investigate slow queries.
 - [Secure-AI-Support-Fabric](https://github.com/nik-kale/Secure-AI-Support-Fabric) *(coming soon)* - Complete lab environment
 
 ### Community
-- [GitHub Discussions](https://github.com/nik-kale/awesome-autonomous-ops/discussions) - Ask questions
+- [GitHub Issues](https://github.com/nik-kale/awesome-autonomous-ops/issues) - Ask questions
 - [Case Studies](./case-studies/) - Real-world implementations
 - [Comparison Matrices](./COMPARISONS.md) - Tool selection guides
 
@@ -367,4 +366,4 @@ Recommendation: Increase connection pool size or investigate slow queries.
 
 ---
 
-**Questions?** Open a [discussion](https://github.com/nik-kale/awesome-autonomous-ops/discussions) or submit an [improvement suggestion](https://github.com/nik-kale/awesome-autonomous-ops/issues/new/choose).
+**Questions?** Open an [issue](https://github.com/nik-kale/awesome-autonomous-ops/issues) or submit an [improvement suggestion](https://github.com/nik-kale/awesome-autonomous-ops/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Tools that perform retrieval-augmented generation, graph-based reasoning, and co
 
 - **[AutoRCA-Core (ADAPT-RCA)](https://github.com/nik-kale/AutoRCA-Core)** *(coming soon)* – Agentic RCA engine with graph-based reasoning over logs, metrics, traces, and configuration changes. Reference implementation for autonomous reliability workflows.
 
-- **[Sage](https://github.com/apple/ml-sage)** – Apple's system for grounding LLM reasoning in structured incident data. Uses semantic search and entity graphs to improve diagnostic accuracy.
-
 - **[LangGraph](https://github.com/langchain-ai/langgraph)** – Framework for building stateful, graph-based AI workflows. Useful for orchestrating multi-step diagnostic and remediation processes with cyclical reasoning.
 
 - **[txtai](https://github.com/neuml/txtai)** – Embeddings database for semantic search over logs and documentation. Enables RAG workflows for incident troubleshooting and knowledge retrieval.
@@ -95,13 +93,11 @@ Model Context Protocol servers and gateways that expose operational tools, ticke
 
 - **[MCP Servers for Kubernetes](https://github.com/kubernetes/kubernetes)** – MCP-compatible interfaces for Kubernetes resources. Enables AI agents to query cluster state and (with proper guardrails) execute kubectl commands.
 
-- **[PulseMCP](https://github.com/pulsemcp/pulsemcp)** – Community directory of MCP servers, including ops-focused implementations for observability and infrastructure tools.
+- **[PulseMCP](https://github.com/pulsemcp/mcp-servers)** – Community directory of MCP servers, including ops-focused implementations for observability and infrastructure tools.
 
 - **[awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)** – Curated list of MCP servers across domains. Filter for observability, infrastructure, and DevOps categories for ops-relevant integrations.
 
-- **[MCP GitHub Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github)** – Official MCP server for GitHub API access. Useful for automated incident ticket creation and PR-based remediation workflows.
-
-- **[MCP Prometheus Server](https://github.com/modelcontextprotocol/servers/tree/main/src/prometheus)** – Official MCP server for Prometheus metrics. Enables AI agents to query time-series data during diagnostic investigations.
+- **[GitHub MCP Server](https://github.com/github/github-mcp-server)** – GitHub's official MCP server for GitHub API access. Useful for automated incident ticket creation and PR-based remediation workflows.
 
 ## Browser & Desktop Ops Agents
 
@@ -177,7 +173,7 @@ The goal is not to build a single monolithic "AI ops platform," but rather to co
 
 ### Community
 
-- **[Discussions](https://github.com/nik-kale/awesome-autonomous-ops/discussions)** - Ask questions, share ideas, connect with practitioners
+- **[Issues](https://github.com/nik-kale/awesome-autonomous-ops/issues)** - Ask questions, share ideas, report problems
 - **[Case Studies](case-studies/)** - Real-world implementations and lessons learned
 - **[Issue Templates](https://github.com/nik-kale/awesome-autonomous-ops/issues/new/choose)** - Submit projects, report issues, suggest improvements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -490,7 +490,7 @@ Transform awesome-autonomous-ops into the **definitive platform** for the autono
 
 **Have ideas for future versions?**
 
-1. **Open a discussion**: [GitHub Discussions](https://github.com/nik-kale/awesome-autonomous-ops/discussions)
+1. **Open an issue**: [GitHub Issues](https://github.com/nik-kale/awesome-autonomous-ops/issues)
 2. **Submit a proposal**: [Improvement issue template](https://github.com/nik-kale/awesome-autonomous-ops/issues/new?template=improvement.yml)
 3. **Vote on proposals**: Upvote issues you'd like to see prioritized
 4. **Contribute code**: Help implement roadmap features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ The security of awesome-autonomous-ops is important to us. If you discover a sec
 
 Instead, please report security issues via:
 
-1. **GitHub Security Advisories**: Use the [Security tab](../../security/advisories/new) to privately report vulnerabilities
+1. **GitHub Security Advisories**: Use the [Security tab](https://github.com/nik-kale/awesome-autonomous-ops/security/advisories/new) to privately report vulnerabilities
 2. **Email**: Contact the maintainer directly (see profile for contact information)
 
 ### What to Include

--- a/case-studies/2025/hitl-remediation-system.md
+++ b/case-studies/2025/hitl-remediation-system.md
@@ -433,7 +433,7 @@ This approval expires in 5 minutes
 
 **Organization**: N/A - Educational Template
 
-**Questions?**: Please open a discussion in the [awesome-autonomous-ops repository](https://github.com/nik-kale/awesome-autonomous-ops/discussions)
+**Questions?**: Please open an issue in the [awesome-autonomous-ops repository](https://github.com/nik-kale/awesome-autonomous-ops/issues)
 
 ---
 

--- a/case-studies/2025/kubernetes-rca-system.md
+++ b/case-studies/2025/kubernetes-rca-system.md
@@ -393,7 +393,7 @@ results = index.search(query, limit=50)
 
 **Organization**: N/A - Educational Template
 
-**Questions?**: Please open a discussion in the [awesome-autonomous-ops repository](https://github.com/nik-kale/awesome-autonomous-ops/discussions)
+**Questions?**: Please open an issue in the [awesome-autonomous-ops repository](https://github.com/nik-kale/awesome-autonomous-ops/issues)
 
 ---
 

--- a/case-studies/2025/slack-investigation-assistant.md
+++ b/case-studies/2025/slack-investigation-assistant.md
@@ -417,7 +417,7 @@ allow {
 
 **Organization**: N/A - Educational Template
 
-**Questions?**: Please open a discussion in the [awesome-autonomous-ops repository](https://github.com/nik-kale/awesome-autonomous-ops/discussions)
+**Questions?**: Please open an issue in the [awesome-autonomous-ops repository](https://github.com/nik-kale/awesome-autonomous-ops/issues)
 
 ---
 

--- a/case-studies/README.md
+++ b/case-studies/README.md
@@ -161,7 +161,7 @@ case-studies/
 
 ## Questions?
 
-- **General questions**: [GitHub Discussions](https://github.com/nik-kale/awesome-autonomous-ops/discussions)
+- **General questions**: [GitHub Issues](https://github.com/nik-kale/awesome-autonomous-ops/issues)
 - **Submission help**: [Open an issue](https://github.com/nik-kale/awesome-autonomous-ops/issues/new/choose)
 - **Privacy concerns**: Email maintainer directly
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def sample_readme_content():
 ## Graph RAG & Root Cause Analysis
 
 - **[AutoRCA-Core](https://github.com/nik-kale/AutoRCA-Core)** *(coming soon)* - Graph RAG and multi-signal root cause analysis engine.
-- **[Sage](https://github.com/apple/ml-sage)** - Apple's system for grounding LLM reasoning in structured incident data.
+- **[LangGraph](https://github.com/langchain-ai/langgraph)** - Framework for building stateful, graph-based AI workflows.
 - **[txtai](https://github.com/neuml/txtai)** - Embeddings database for semantic search over logs.
 
 ## Agentic Remediation & Runbooks


### PR DESCRIPTION
## Summary

Fixes all 26 broken links flagged by Lychee in issue #19.

**Dead/moved projects:**
- Removed `apple/ml-sage` (repo deleted, no replacement)
- Updated PulseMCP URL to `pulsemcp/mcp-servers` (repo renamed)
- Replaced MCP monorepo subdir links (`modelcontextprotocol/servers/tree/main/src/github` and `/src/prometheus`) with `github/github-mcp-server` (the new official standalone repo); removed Prometheus entry (archived, no official successor)

**Discussions links (feature not enabled):**
- Replaced all `/discussions` links with `/issues` across README, GETTING-STARTED, ROADMAP, case studies, and issue template config (8 files)

**Other fixes:**
- CHANGELOG version comparison links now point to actual commit refs instead of nonexistent git tags
- SECURITY.md advisory link changed from relative to absolute URL
- Excluded `*.html` from Lychee scan (Jekyll Liquid templates produce false positives pre-build)
- Added `.lycheeignore` for remaining template patterns

Closes #19

## Test plan

- [ ] Verify Lychee link checker passes on this PR
- [ ] Spot-check that updated URLs resolve (PulseMCP, GitHub MCP Server)

Made with [Cursor](https://cursor.com)