### PR TITLE
fix: escape Liquid template pattern in .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,5 +1,5 @@
 # Jekyll Liquid template URLs (only valid after build)
-{{ site.github.repository_url }}
+.*site\.github\.repository_url.*
 
 # Relative paths without extensions (resolved by Jekyll/GitHub Pages)
 file:///.*COMPARISONS$


### PR DESCRIPTION
The `.lycheeignore` file added in PR #20 contained raw `{{ site.github.repository_url }}` which Lychee interprets as regex. The `{{` is invalid regex syntax, causing Lychee to crash with "repetition operator missing expression" -- which then triggered the auto-issue-creation step, producing issue #21.

Replaces the literal Liquid template with a regex matching the variable name.

Closes #21

Made with [Cursor](https://cursor.com)